### PR TITLE
fix: patch via task_suspend instead of ptrace (fixes SIGSEGV on every apply)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/platform-macOS-black" alt="Platform" />
   <img src="https://img.shields.io/badge/tauri-2-24C8D8" alt="Tauri" />
   <img src="https://img.shields.io/badge/react-19-61DAFB" alt="React" />
-  <img src="https://img.shields.io/badge/version-0.1.9-c89b3c" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.1.10-c89b3c" alt="Version" />
 </p>
 
 <p align="center">

--- a/mod-tools/lib/patcher/patcher.hpp
+++ b/mod-tools/lib/patcher/patcher.hpp
@@ -5,6 +5,14 @@
 #include <fs.hpp>
 
 namespace lol::patcher {
+    /// Writes one diagnostic line to stderr, which Zushi captures and echoes.
+    void patch_log(char const* fmt, ...) noexcept __attribute__((format(printf, 1, 2)));
+
+    /// Resumes a game frozen by Process::Suspend(). Call from a termination
+    /// handler: a suspend count outlives the process that took it, so dying
+    /// mid-patch would otherwise leave the game frozen for good.
+    void emergency_resume() noexcept;
+
     enum Message {
         M_WAIT_START,
         M_FOUND,

--- a/mod-tools/lib/patcher/patcher_macos_arm64.cpp
+++ b/mod-tools/lib/patcher/patcher_macos_arm64.cpp
@@ -175,6 +175,17 @@ static PtrStorage find_wad_verify(const uint8_t* text_beg, const uint8_t* text_e
     return bl_pc + (int64_t)offset * 4;
 }
 
+// Runs one patch step, naming it in the log if the kernel rejects it.
+template <typename F>
+static auto patch_step(char const* what, F&& step) -> void {
+    try {
+        step();
+    } catch (std::exception const& e) {
+        patch_log("patch step FAILED [%s]: %s", what, e.what());
+        throw;
+    }
+}
+
 struct Context {
     std::uint64_t off_wad_verify = {};
     std::uint64_t off_fopen_ptr = {};
@@ -232,15 +243,18 @@ struct Context {
         payload_wad_verify.fopen_hook_ptr = (PtrStorage)ptr_fopen_hook;
 
         // Write shellcode to newly allocated memory (not code-signed).
+        // Each step is logged on failure: without a debugger attached the
+        // kernel may refuse to make memory executable in another process, and
+        // the log needs to say exactly which call was rejected.
         ptr_fopen_hook_addr = (PtrStorage)ptr_fopen_hook;
-        process.MarkWritable(ptr_fopen_hook);
-        process.Write(ptr_fopen_hook, payload_fopen);
-        process.MarkExecutable(ptr_fopen_hook);
+        patch_step("hook: mark writable", [&] { process.MarkWritable(ptr_fopen_hook); });
+        patch_step("hook: write payload", [&] { process.Write(ptr_fopen_hook, payload_fopen); });
+        patch_step("hook: mark executable", [&] { process.MarkExecutable(ptr_fopen_hook); });
 
-        // Write wad_verify bypass (modifies __TEXT.__text - works with CS_DEBUGGED).
-        process.MarkWritable(ptr_wad_verify);
-        process.Write(ptr_wad_verify, payload_wad_verify);
-        process.MarkExecutable(ptr_wad_verify);
+        // Write wad_verify bypass (modifies __TEXT.__text).
+        patch_step("wad_verify: mark writable", [&] { process.MarkWritable(ptr_wad_verify); });
+        patch_step("wad_verify: write bypass", [&] { process.Write(ptr_wad_verify, payload_wad_verify); });
+        patch_step("wad_verify: mark executable", [&] { process.MarkExecutable(ptr_wad_verify); });
     }
 };
 
@@ -297,6 +311,7 @@ auto patcher::run(std::function<void(Message, char const*)> update,
                 if (process.TryReadMemory((void*)(uintptr_t)ptr_wad_verify, probe, sizeof(probe))
                     && std::memcmp(probe, expected.return_true, sizeof(probe)) == 0) {
                     // Already patched — just wait for this game to exit
+                    patch_log("pid=%u already patched, waiting for exit", pid);
                     last_patched_pid = pid;
                     update(M_WAIT_EXIT, "");
                     run_until_or(
@@ -311,10 +326,23 @@ auto patcher::run(std::function<void(Message, char const*)> update,
 
             update(M_PATCH, "");
 
-            // Phase 1: Freeze process, write shellcode + wad_verify bypass
-            process.PtraceAttach();
-            ctx.patch(process);
-            process.PtraceDetach();
+            // Phase 1: Freeze process, write shellcode + wad_verify bypass.
+            //
+            // Freezing is done with task_suspend rather than ptrace. League
+            // denies debugger attachment within milliseconds of launching, and
+            // the kernel answers an attach attempt by killing the caller, so
+            // ptrace is not usable here at all. task_suspend goes through the
+            // task port we already hold and never makes us a debugger.
+            process.Suspend();
+            {
+                struct ResumeGuard {
+                    Process const& process;
+                    ~ResumeGuard() noexcept { process.Resume(); }
+                } resume_guard{process};
+
+                ctx.patch(process);
+            }
+            patch_log("patched pid=%u", pid);
 
             // Phase 2: Wait for dyld to resolve fopen lazy binding, then overwrite
             // with our hook. macOS 26 eagerly resolves lazy bindings after process
@@ -350,8 +378,7 @@ auto patcher::run(std::function<void(Message, char const*)> update,
             throw;  // user-initiated abort: propagate so mod_runoverlay can clean up
         } catch (std::exception const& e) {
             last_patched_pid = pid;  // don't hot-spin on the same broken PID
-            std::fprintf(stderr, "[patcher] iteration failed for pid=%u: %s\n", pid, e.what());
-            std::fflush(stderr);
+            patch_log("failed for pid=%u: %s", pid, e.what());
             // Fall through to next iteration — patcher stays alive and keeps watching.
         }
     }

--- a/mod-tools/lib/patcher/utility/process.hpp
+++ b/mod-tools/lib/patcher/utility/process.hpp
@@ -3,6 +3,8 @@
 #include <fs.hpp>
 #include <optional>
 
+#include <patcher/patcher.hpp>
+
 namespace lol::patcher {
     template <typename T>
     struct Ptr;
@@ -90,8 +92,11 @@ namespace lol::patcher {
 
         auto AllocateMemory(size_t size) const -> void *;
 
-        auto PtraceAttach() const -> void;
-        auto PtraceDetach() const -> void;
+        /// Freezes / unfreezes every thread via the task port. Unlike ptrace
+        /// this does not make us a debugger, so League's deny-attach guard is
+        /// never triggered.
+        auto Suspend() const -> void;
+        auto Resume() const noexcept -> void;
 
         template <typename T>
         inline auto TryRead(Ptr<T> address) const noexcept -> std::optional<T> {

--- a/mod-tools/lib/patcher/utility/process_macos.cpp
+++ b/mod-tools/lib/patcher/utility/process_macos.cpp
@@ -3,12 +3,12 @@
 
 #    include "process.hpp"
 // do not reoder
+#    include <atomic>
+#    include <cstdarg>
 #    include <libproc.h>
 #    include <mach/mach.h>
 #    include <mach/mach_traps.h>
 #    include <mach/mach_vm.h>
-#    include <sys/ptrace.h>
-#    include <sys/wait.h>
 #    include <unistd.h>
 
 using namespace lol;
@@ -204,25 +204,40 @@ auto Process::AllocateMemory(size_t size) const -> void* {
     return (void*)address;
 }
 
-auto Process::PtraceAttach() const -> void {
-    // PT_ATTACH is deprecated on macOS in favor of PT_ATTACHEXC, but in this
-    // codebase PT_ATTACHEXC actually crashes inside __ptrace on macOS 26. The
-    // deprecation warning is acknowledged; we stay on PT_ATTACH because it
-    // works. The real reliability gain is in the caller: always PtraceDetach
-    // after a successful attach, even if the patch step throws.
-    if (ptrace(PT_ATTACH, pid_, nullptr, 0) == -1) {
-        lol_throw_msg("ptrace PT_ATTACH (pid: {}): errno {}", pid_, errno);
-    }
-    int status = 0;
-    if (waitpid(pid_, &status, WUNTRACED) == -1) {
-        ptrace(PT_DETACH, pid_, (caddr_t)1, 0);
-        lol_throw_msg("waitpid (pid: {}): errno {}", pid_, errno);
-    }
+// Patcher diagnostics go to stderr, which Zushi already captures and echoes.
+void lol::patcher::patch_log(char const* fmt, ...) noexcept {
+    std::fprintf(stderr, "[patcher] ");
+    va_list args;
+    va_start(args, fmt);
+    std::vfprintf(stderr, fmt, args);
+    va_end(args);
+    std::fputc('\n', stderr);
+    std::fflush(stderr);
 }
 
-auto Process::PtraceDetach() const -> void {
-    if (ptrace(PT_DETACH, pid_, (caddr_t)1, 0) == -1) {
-        lol_throw_msg("ptrace PT_DETACH (pid: {}): errno {}", pid_, errno);
+// Task currently frozen by Suspend(), so a termination signal can thaw it. If
+// the patcher died in the middle of patching, the game would otherwise stay
+// suspended forever: unlike a ptrace attachment, a suspend count is not
+// released when the process holding it goes away.
+static std::atomic<mach_port_t> g_suspended_task = {};
+
+auto Process::Suspend() const -> void {
+    auto const task = (task_t)(uintptr_t)handle_;
+    if (auto const err = task_suspend(task)) {
+        lol_throw_msg("task_suspend: {:#x}", (std::uint32_t)err);
+    }
+    g_suspended_task.store(task, std::memory_order_release);
+}
+
+auto Process::Resume() const noexcept -> void {
+    auto const task = (task_t)(uintptr_t)handle_;
+    g_suspended_task.store(0, std::memory_order_release);
+    task_resume(task);
+}
+
+void lol::patcher::emergency_resume() noexcept {
+    if (auto const task = g_suspended_task.exchange(0, std::memory_order_acq_rel)) {
+        task_resume(task);
     }
 }
 

--- a/mod-tools/main.cpp
+++ b/mod-tools/main.cpp
@@ -10,7 +10,9 @@
 #include <utility/zip.hpp>
 #include <wad/archive.hpp>
 #include <wad/index.hpp>
+#include <chrono>
 #include <thread>
+#include <unistd.h>
 #include <unordered_set>
 
 using namespace lol;
@@ -246,18 +248,27 @@ static auto mod_runoverlay(fs::path overlay, fs::path config_file, fs::path game
         setbuf(stdin, nullptr);
         for (;;) {
             int c = fgetc(stdin);
-            if (c == '\n' && !*lock) {
-                fflush(stdout);
-                exit(0);
+            if (c != '\n' && c != -1) continue;
+            patcher::patch_log("runoverlay: shutdown requested (%s), patch_in_flight=%s",
+                               c == -1 ? "stdin EOF" : "newline",
+                               *lock ? "YES - waiting" : "no");
+            // Abort requested (newline), or the parent dropped the pipe (EOF).
+            // Either way, never tear down while a patch is in flight: the game
+            // is suspended for that window, and a suspend count is not released
+            // when the holder exits, so leaving now would freeze the game for
+            // good. Wait for the patch to land.
+            while (*lock) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
-            if (c == -1) {
-                exit(0);
-            }
+            patcher::patch_log("runoverlay: exiting now");
+            fflush(stdout);
+            exit(0);
         }
     });
     thread.detach();
 
     fmtlog::setLogFile(stdout, false);
+    patcher::patch_log("runoverlay: START overlay=%s game=%s", overlay.c_str(), game.c_str());
     auto old_msg = patcher::M_DONE;
     try {
         patcher::run(
@@ -320,6 +331,22 @@ int main(int argc, char** argv) {
         sigemptyset(&sa.sa_mask);
         sa.sa_flags = 0;
         sigaction(SIGPIPE, &sa, nullptr);
+    }
+
+    // Patching freezes the game with task_suspend. A suspend count is not
+    // released when the holder dies, so being terminated mid-patch would leave
+    // the game frozen for good — thaw it before going away.
+    {
+        struct sigaction sa = {};
+        sa.sa_handler = [](int sig) {
+            patcher::emergency_resume();
+            _exit(128 + sig);
+        };
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        sigaction(SIGTERM, &sa, nullptr);
+        sigaction(SIGINT, &sa, nullptr);
+        sigaction(SIGHUP, &sa, nullptr);
     }
 
     utility::set_binary_io();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zushi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5374,7 +5374,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zushi"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zushi"
-version = "0.1.9"
+version = "0.1.10"
 description = "A lightweight desktop app to browse and apply League of Legends skins."
 authors = ["you"]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Zushi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.zushi.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Resolves #16
Resolves #17

## Problem

On macOS the patcher is killed by `SIGSEGV` as soon as it tries to patch a game. Skins apply for one game at most, and after that every apply fails until Zushi is fully restarted.

Crash reports show `mod-tools` dying inside `Process::PtraceAttach()`:

```
EXC_CRASH (SIGSEGV)   termination: byProc mod-tools, byPid <self>
  libsystem_kernel.dylib  __ptrace + 0x14
  lol::patcher::Process::PtraceAttach() const
  lol::patcher::run(...)
```

Two details identify the mechanism. The exception is `EXC_CRASH` — a *delivered signal* — not `EXC_BAD_ACCESS`, so this is not a bad pointer. And `pc` sits on the instruction immediately after the `ptrace` `svc`, with the carry flag set and `x0 = 16`, meaning the syscall returned `EBUSY`.

## Cause

League calls `ptrace(PT_DENY_ATTACH)` on itself shortly after launching. From that point macOS answers *any* attach attempt by sending `SIGSEGV` to the **attacher** and returning `EBUSY`. Reduced to a standalone repro:

```
[victim, PT_DENY_ATTACH=no ]  attacher survived
[victim, PT_DENY_ATTACH=YES]  attacher KILLED by signal 11
```

This is not recoverable from the calling side:

- The caller dies *inside* the syscall, so there is no error to catch.
- The deny state is not exposed through `sysctl` or `proc_pidinfo`, so it cannot be tested for beforehand — the game reports as untraced right up to the moment the attach kills us.
- The window before the game sets it is far too small to race; instrumented runs showed the game already denying at ~40 ms of process age, well under the time it takes to even discover the process.

### Why this also explains the game crashing on launch (#16)

The same kernel behaviour has a second, opposite failure mode. If a process calls `PT_DENY_ATTACH` *while it is already traced*, the kernel terminates **it** rather than the tracer. Verified in isolation:

```
untraced:  "SURVIVED the PT_DENY_ATTACH call"  -> exits 0 normally
traced:    "calling PT_DENY_ATTACH now" ... process GONE
```

So the two reported symptoms are the same root cause on either side of a race:

- Patcher attaches **after** the game's deny call -> the *patcher* is killed (#17, `Patcher exited unexpectedly (killed by signal 11)`).
- Patcher attaches **before** it and is still attached when the game makes the call -> the *game* is killed (#16, crash on launch and the skin not loading). The stale "in game" status follows from the patcher never seeing a clean exit.

Removing ptrace resolves both: the game is never traced, so neither side can be shot.

## Fix

`ptrace` was only ever used to freeze the game while patching — the memory writes themselves go through the Mach task port from `task_for_pid`. So freezing now uses `task_suspend()` / `task_resume()` on that same port. That is not debugger attachment, so the deny guard never triggers, and the patch proceeds unchanged.

Supporting changes:

- **Resume on every path.** A `ResumeGuard` covers a throwing patch step, and `SIGTERM`/`SIGINT`/`SIGHUP` thaw the game before exit. This matters because a ptrace attachment is released when the tracer dies, but **a suspend count is not** — being killed mid-patch would otherwise leave the game frozen permanently.
- **Don't tear down mid-patch.** `runoverlay`'s stdin reader called `exit(0)` on EOF regardless of the in-flight guard sitting next to it. Zushi's re-apply closes that pipe, so it could land during a patch. It now waits for the patch to finish.
- **Per-step patch logging**, so a rejected `mach_vm_*` call names which step failed.
- Removed the now-unused `PtraceAttach` / `PtraceDetach`.

## Testing

- Verified on macOS 26.4.1 (Apple Silicon): skins apply correctly in-game, and the patcher survives repeated applies without crashing or needing a restart.
- Builds clean with no warnings. The previous `PT_ATTACH is deprecated` warning is gone, as `sys/ptrace.h` is no longer included.

Only the arm64 patcher path is affected; `patcher_macos_amd64.cpp` never used ptrace.
